### PR TITLE
GCP: Maintenance Release updates

### DIFF
--- a/gcp/scripts/env.sh
+++ b/gcp/scripts/env.sh
@@ -24,7 +24,7 @@ JENKINS_HELM_RELEASENAME="ci"
 ADDRESS=gcr.io
 SERVICE_ACCOUNT_DEST=~/.gcp/gcp-account.json
 REGISTRY_NAME=gcpimagerepository
-SPINNAKER_VERSION="1.7.5"
+SPINNAKER_VERSION="1.8.0"
 CANARY_METRIC_STORE="stackdriver"
 
 DOCKER_HUB_NAME="dockerhubimagerepository"

--- a/gcp/scripts/env.sh
+++ b/gcp/scripts/env.sh
@@ -24,7 +24,7 @@ JENKINS_HELM_RELEASENAME="ci"
 ADDRESS=gcr.io
 SERVICE_ACCOUNT_DEST=~/.gcp/gcp-account.json
 REGISTRY_NAME=gcpimagerepository
-SPINNAKER_VERSION="1.8.0"
+SPINNAKER_VERSION="1.8.6"
 CANARY_METRIC_STORE="stackdriver"
 
 DOCKER_HUB_NAME="dockerhubimagerepository"

--- a/gcp/scripts/halyard_createSpinnaker.sh
+++ b/gcp/scripts/halyard_createSpinnaker.sh
@@ -46,12 +46,14 @@ hal config storage edit --type gcs
 
 hal config features edit --pipeline-templates true
 
+hal config features edit --artifacts true
+
 
 echo "==== -> Let's Get a Docker Registry using gcr.io added"
 
 ###  make HAL not puke over empty GCR resistry https://github.com/spinnaker/halyard/issues/608
-sudo docker pull nginx
-sudo docker tag nginx:latest $ADDRESS/$PROJECT_NAME/nginx
+sudo docker pull gcr.io/google_containers/nginx
+sudo docker tag gcr.io/google_containers/nginx $ADDRESS/$PROJECT_NAME/nginx
 sudo gcloud docker -- push $ADDRESS/$PROJECT_NAME/nginx
 #### end 
 

--- a/gcp/scripts/halyard_createSpinnaker.sh
+++ b/gcp/scripts/halyard_createSpinnaker.sh
@@ -81,8 +81,8 @@ hal config provider docker-registry enable
 
 echo "==== -> Let's get K8 on GKE associated using gcr.io added"
 
-#CONTEXT_prefix="gke_"
-#CONTEXT=$CONTEXT_prefix$PROJECT_NAME\_$CLUSTER_ZONE\_$CLUSTER_NAME
+
+
 
 IMAGE_REPOS="$REGISTRY_NAME,$DOCKER_HUB_NAME"
 

--- a/gcp/scripts/halyard_createSpinnaker.sh
+++ b/gcp/scripts/halyard_createSpinnaker.sh
@@ -64,7 +64,7 @@ hal config storage edit --type gcs
 
 hal config features edit --pipeline-templates true
 
-hal config features edit --artifacts true
+#hal config features edit --artifacts true
 
 
 echo "==== -> Let's Get a Docker Registry using gcr.io added"
@@ -86,7 +86,7 @@ echo "==== -> Let's get K8 on GKE associated using gcr.io added"
 
 IMAGE_REPOS="$REGISTRY_NAME,$DOCKER_HUB_NAME"
 
-hal config provider kubernetes account add $HALYARD_K8_ACCOUNT_NAME  --context $CONTEXT --docker-registries $IMAGE_REPOS --omit-namespaces $OMIT_NAMESPACES  --provider-version v2
+hal config provider kubernetes account add $HALYARD_K8_ACCOUNT_NAME  --context $CONTEXT --docker-registries $IMAGE_REPOS --omit-namespaces $OMIT_NAMESPACES
 
 hal config deploy edit --type distributed --account-name $HALYARD_K8_ACCOUNT_NAME
 

--- a/gcp/scripts/spinnaker-svcacct.yml
+++ b/gcp/scripts/spinnaker-svcacct.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spinnaker-service-account
+  namespace: spinnaker
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spinnaker-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: spinnaker-service-account
+  namespace: spinnaker


### PR DESCRIPTION
#opensourcedevops
So, if you look at this page: https://www.spinnaker.io/community/releases/versions/  you will see many versions get deprecated. Well, the last version of capstan used a version that is no longer supported and true to form the bootstrap container used during installation fails to...bootstrap the installation. This PR fixes that. 

This PR performs the following


- Changes where we obtain nginx to fill local docker repo from dockerhub to google's  #26 
- update spinnaker to 1.8.6, previous version deprecated 
- Spinnaker now uses a service account #21 

