### PR TITLE
Add back getting the spin CLI

### DIFF
--- a/gcp/scripts/instance_execute.sh
+++ b/gcp/scripts/instance_execute.sh
@@ -61,12 +61,12 @@ sudo mv roer-linux-amd64 /usr/local/bin/roer
 echo ">>>> Add the SPINNAKER_API environ"
 echo -e "\nexport SPINNAKER_API=http://127.0.0.1:8084\n" >> ~/.profile
 
-#### We need expect also
-#sudo apt-get install expect -y
-
-echo ">>>> Get Docker"
-#### this is not a version you would want to use but it will get the job done
-#sudo apt-get install -y docker.io
+echo ">>>>> get spin"
+curl -LO https://storage.googleapis.com/spinnaker-artifacts/spin/$(curl -s https://storage.googleapis.com/spinnaker-artifacts/spin/latest)/linux/amd64/spin
+chmod +x spin
+sudo mv spin /usr/local/bin/spin
+mkdir ~/.spin
+touch ~/.spin/config
 
 echo $PWD
 echo "=========================================="


### PR DESCRIPTION
overuse of delete. We want to remove of the docker reference but not the spin CLI